### PR TITLE
Update config port hierarchy to look at .yml file first before comman…

### DIFF
--- a/dynamodb/starter.js
+++ b/dynamodb/starter.js
@@ -7,7 +7,7 @@ var starter = {
     start: function (options, config) {
         /* Dynamodb local documentation http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html */
         var additionalArgs = [],
-            port = options.port || config.start.port,
+            port = config.start.port || options.port,
             db_dir = utils.absPath(config.setup.install_path),
             jar = config.setup.jar;
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var dynamodb = {
                 console.log('DynamoDB Local failed to start with code', code);
             }
         });
-        console.log('Dynamodb Local Started, Visit: http://localhost:' + (options.port || config.start.port) + '/shell');
+        console.log('Dynamodb Local Started, Visit: http://localhost:' + (instance.port) + '/shell');
     },
     stop: function(port) {
         if (dbInstances[port]) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,180 @@
+{
+    "name": "npm-dynamodb-localhost",
+    "version": "0.0.5",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "block-stream": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+            "requires": {
+                "inherits": "~2.0.0"
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "fstream": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+            }
+        },
+        "glob": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "is": {
+            "version": "0.2.7",
+            "resolved": "http://registry.npmjs.org/is/-/is-0.2.7.tgz",
+            "integrity": "sha1-OzSixI81mXLzUEKEkZOucmS2NWI="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "node.extend": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.0.8.tgz",
+            "integrity": "sha1-urBDefc4P0WHmQyd8Htqf2Xbdys=",
+            "requires": {
+                "is": "~0.2.6",
+                "object-keys": "~0.4.0"
+            }
+        },
+        "node.flow": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/node.flow/-/node.flow-1.2.3.tgz",
+            "integrity": "sha1-4cRKgq7KjXi0WKd/s9xkLy66Jkk=",
+            "requires": {
+                "node.extend": "1.0.8"
+            }
+        },
+        "object-keys": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+            "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "progress": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+            "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+        },
+        "rimraf": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "requires": {
+                "glob": "^7.0.5"
+            }
+        },
+        "rmdir": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/rmdir/-/rmdir-1.2.0.tgz",
+            "integrity": "sha1-T+A1fLBhaMJY5z6WgJPcTooPMlM=",
+            "requires": {
+                "node.flow": "1.2.3"
+            }
+        },
+        "tar": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "requires": {
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "npm-dynamodb-localhost",
+    "name": "dynamodb-localhost",
     "version": "1.0.0",
     "engines": {
         "node": ">=4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "dynamodb-localhost",
-    "version": "0.0.5",
+    "name": "npm-dynamodb-localhost",
+    "version": "1.0.0",
     "engines": {
         "node": ">=4.0"
     },
@@ -9,7 +9,7 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/Vin65/dynamodb-localhost"
+        "url": "https://github.com/Vin65/npm-dynamodb-localhost"
     },
     "keywords": [
         "aws",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "npm-dynamodb-localhost",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "engines": {
         "node": ">=4.0"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dynamodb-localhost",
-    "version": "1.0.0",
+    "version": "0.0.5",
     "engines": {
         "node": ">=4.0"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "dynamodb-localhost",
-    "version": "0.0.5",
+    "name": "npm-dynamodb-localhost",
+    "version": "1.0.0",
     "engines": {
         "node": ">=4.0"
     },
@@ -9,21 +9,21 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/99xt/dynamodb-localhost"
+        "url": "https://github.com/Vin65/dynamodb-localhost"
     },
     "keywords": [
-    "aws",
-    "dynamodb",
-    "dynamo",
-    "testing",
-    "development",
-    "tool",
-    "local",
-    "localhost",
-    "local-dynamodb",
-    "dynamodb-local",
-    "dynamodb-localhost"
-  ],
+        "aws",
+        "dynamodb",
+        "dynamo",
+        "testing",
+        "development",
+        "tool",
+        "local",
+        "localhost",
+        "local-dynamodb",
+        "dynamodb-local",
+        "dynamodb-localhost"
+    ],
     "main": "index.js",
     "bin": {},
     "dependencies": {


### PR DESCRIPTION
## What did you implement:

Closes: https://github.com/99xt/serverless-dynamodb-local/issues/135

## How did you implement it:

I swapped the order of the port configuration so that it first checks to see if you've defined a port within your serverless.yml file rather than if you've passed one in via the command line.

This may or may not be an issue for people who are currently using this plugin. My line of thinking was that if they are passing a port through the command line today, it will be setting their localhost server which hosts their api gateway endpoints on the same port. (which will error) Not everyone uses API Gateway so there could be some cases out there that this doesn't apply to. If someone is running multiple dynamoDB databases and they are using the `--port` command line flag to specifically define a port, is there a use case where they would need to set a port within their serverless.yml file?

### Documentation updates pertain to: https://github.com/99xt/serverless-dynamodb-local/blob/v1/README.md#install-sls-dynamodb-install
## Start: sls dynamodb start
All CLI options are optional:

```
--port  		  -p  Port to listen on. Default: 8000. This flag is overridden by the serverless.yml custom option detailed below.
```

All the above options can be added to serverless.yml to set default configuration: e.g.

```yml
custom:
  dynamodb:
    start:
      port: 8000 # This option will override the CLI option --port
      inMemory: true
      migrate: true
      seed: true
    # Uncomment only if you already have a DynamoDB running locally
    # noStart: true
```



## Todos:

- [x] Write documentation
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** MAYBE for some users.
