### PR TITLE
Add support for dockerized DynamoDBLocal

### DIFF
--- a/dynamodb/starter.js
+++ b/dynamodb/starter.js
@@ -39,17 +39,28 @@ var starter = {
             additionalArgs.push('-help');
         }
 
-        var args = ['-Djava.library.path=' + db_dir + '/DynamoDBLocal_lib', '-jar', jar, '-port', port];
-        args = preArgs.concat(args.concat(additionalArgs));
+        var args = ['-jar', jar, '-port', port];
+        var executable;
+        var cwd;
 
-        var child = spawn('java', args, {
-            cwd: db_dir,
+        if (options.docker) {
+            executable = process.env.DOCKER_PATH || 'docker';
+            preArgs = ['run', '-d', '-p', port + ':' + port, process.env.DOCKER_IMAGE || 'amazon/dynamodb-local'];
+        } else {
+            executable = 'java';
+            preArgs.push('-Djava.library.path=' + db_dir + '/DynamoDBLocal_lib');
+            cwd = db_dir;
+        }
+
+        args = preArgs.concat(args.concat(additionalArgs));
+        var child = spawn(executable, args, {
+            cwd: cwd,
             env: process.env,
             stdio: ['pipe', 'pipe', process.stderr]
         });
 
         if (!child.pid) {
-            throw new Error('Unable to start DynamoDB Local process! Make sure you have java executable in your path.');
+            throw new Error('Unable to start DynamoDB Local process! Make sure you have ' + executable + ' executable in your path.');
         }
 
         child.on('error', function (code) {


### PR DESCRIPTION
This adds a new option  which if true starts DynamoDB using docker.
Enabling support for docker resolves some issues with running the DynamoDB Java server on incompatible
architectures such as Apple M1.

If the option `docker` is truthy, instead of spawning a `java` process, a `docker` process is spawned, such as 

    docker run -d -p 8000:8000 amazon/dynamodb-local -jar DynamoDBLocal.jar -port 8000 -sharedDb -inMemory

The same arguments are supported as when running DynamoDBLocal using java on the localhost.

Customization:

The following environment variables may be used to customize the docker behaviour:

* DOCKER_PATH - the path to the docker executable. Default: 'docker'
* DOCKER_IMAGE - the name of the docker image. Default: 'amazon/dynamodb-local'

