### PR TITLE
Dockerized DynamoDBLocal accepts dbPath option

### DIFF
--- a/dynamodb/starter.js
+++ b/dynamodb/starter.js
@@ -19,7 +19,7 @@ var starter = {
             preArgs.push(`-Xmx${options.heapMax}`);
         }
         if (options.dbPath) {
-            additionalArgs.push('-dbPath', options.dbPath);
+            additionalArgs.push('-dbPath', options.docker ? 'dbpath' : options.dbPath);
         } else {
             additionalArgs.push('-inMemory');
         }
@@ -45,7 +45,11 @@ var starter = {
 
         if (options.docker) {
             executable = process.env.DOCKER_PATH || 'docker';
-            preArgs = ['run', '-d', '-p', port + ':' + port, process.env.DOCKER_IMAGE || 'amazon/dynamodb-local'];
+            preArgs = ['run', '-p', port + ':' + port];
+            if (options.dbPath) {
+                preArgs.push('--mount', 'type=bind,source=' + options.dbPath + ',target=/home/dynamodblocal/dbpath');
+            }
+            preArgs.push(process.env.DOCKER_IMAGE || 'amazon/dynamodb-local')
         } else {
             executable = 'java';
             preArgs.push('-Djava.library.path=' + db_dir + '/DynamoDBLocal_lib');


### PR DESCRIPTION
This fix allows very useful Dockerized DynamoDBLocal to accept `dbPath` option to keep data persistent. The current docker mode works differently from local jar mode in two places:

* `dbPath` option doesn't work with `docker: true` option because DynamoDBLocal writes files inside the container.
* `dynamodb.stop()` doesn't stop DynamoDBLocal because `-d` option in `docker run` command keeps the container running.

To make docker mode work as same way as local jar, we need to mount the dbPath directory to the container, and to remove `-d` option like this:

```
docker run -p 8000:8000 amazon/dynamodb-local --mount type=bind,source=$(dbPath),target=/home/dynamodblocal/dbpath -jar DynamoDBLocal.jar -port 8000 -sharedDb -dbPath=dbpath
```

`/home/dynamodblocal/dbpath` is arbitrary directory name inside the container while dbPath is specified by the user.
